### PR TITLE
Override default toolchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,7 +459,7 @@ checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
 name = "ptarmigan"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "fitsio",
  "memoffset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ptarmigan"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["tgblackburn"]
 edition = "2018"
 publish = false

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.47.0"


### PR DESCRIPTION
Compiling with 1.48+ succeeds, but tests fail due to
mem::uninitialized errors associated with linked_hash_map,
used in yaml-rust and therefore in the input parsing.

Until this is fixed upstream, freeze toolchain to last
working version, i.e. 1.47.0.